### PR TITLE
feat: auto-inject mae health routes in #[run_app] macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,9 @@ pub fn run_app(_: TokenStream, input: TokenStream) -> TokenStream {
                  .app_data(web::Data::new(db_pool.clone()))
                  .app_data(web::Data::new(graph_pool.clone()))
                  .app_data(web::Data::new(custom_context.clone()))
+                 .service(mae::health::health)
+                 .service(mae::health::health_pg)
+                 .service(mae::health::health_neo)
              .#fn_block
          })
          .listen(listener)?


### PR DESCRIPTION
## Summary
Auto-inject mae health routes into the app builder chain inside #[run_app] so every service gets /health, /health-pg, /health-neo for free without any service-level code.

## Changes
- Inject mae::health::health, mae::health::health_pg, mae::health::health_neo into the Actix app builder in the #[run_app] macro

Closes #10

## Test Results
- cargo +nightly fmt -- --check ✅
- cargo +nightly clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks ✅
- cargo +nightly miri test --lib ⏭️ (proc-macro crate, not required per instructions)
- cargo +nightly test --features integration-tests ⏭️ (not required per instructions)
- cargo +nightly deny check ⏭️ (not required per instructions)
- cargo +nightly llvm-cov --lib ⏭️ (not required per instructions)
