### PR TITLE
fix: use mae::repo::macros::MaeRepo in generated derive; bump to 0.1.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mae_macros"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 license = "MIT"
 description = "Procedural macros for Mae-Technologies micro-services — derive helpers, schema binding, and async test harness."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,7 @@ pub fn schema(args: TokenStream, input: TokenStream) -> TokenStream {
     let repo = quote! {
 
         #(#repo_attrs)*
-        #[derive(mae_macros::MaeRepo, Debug, sqlx::FromRow, serde::Serialize, serde::Deserialize, Clone)]
+        #[derive(mae::repo::macros::MaeRepo, Debug, sqlx::FromRow, serde::Serialize, serde::Deserialize, Clone)]
         pub struct #repo_ident {
             #[locked]
             pub id: i32,
@@ -323,7 +323,7 @@ pub fn schema_root(args: TokenStream, input: TokenStream) -> TokenStream {
 
     let repo = quote! {
         #(#repo_attrs)*
-        #[derive(mae_macros::MaeRepo, Debug, sqlx::FromRow, serde::Serialize, serde::Deserialize, Clone)]
+        #[derive(mae::repo::macros::MaeRepo, Debug, sqlx::FromRow, serde::Serialize, serde::Deserialize, Clone)]
         pub struct #repo_ident {
             #[locked]
             pub id: i32,


### PR DESCRIPTION
Generated code previously hardcoded 'mae_macros::MaeRepo' requiring downstream services to have mae_macros as a direct dependency. Switched to the re-exported path 'mae::repo::macros::MaeRepo' (available via pub use mae_macros::* in mae 0.3.9+) so services only need 'mae' as a dep.